### PR TITLE
Make 32-bit installations work

### DIFF
--- a/octopose.py
+++ b/octopose.py
@@ -37,7 +37,10 @@ def invoke_deploy(step_path):
     """invoke_deploy start a deploy for a given powershell script (*Deploy.ps1)"""
     if os.path.exists(step_path):
         print("- {0}".format(step_path))
-        args = "powershell.exe {0}".format(step_path)
+        if sys.maxsize > 2**32:
+            args = "powershell.exe {0}".format(step_path)
+        else:
+            args = "c:\\windows\\sysnative\\cmd.exe /c powershell.exe {0}".format(step_path)
         subprocess.call(args, shell=False)
 
 


### PR DESCRIPTION
#12 fixy fixy

Sysnative allows access to the 64-bit powershell installation from a program running under 32-bit. This avoids COM exceptions that occur when running the deploy scripts using 32-bit powershell.