### PR TITLE
Verbose logging

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 Huddle
+Copyright (c) 2018 Huddle
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -154,8 +154,10 @@ python .\octopose.py -e uklive .\manifest.json
 
 `--wait` flag will cause **octopose** to continually poll the Octopus Deploy Tasks till they are complete.
 
+`--verbose` (or `-v`) flag will cause **octopose** to output all logs from the `*Deploy.ps1` files. Otherwise there will only be logs from a script if a non-zero exit code is returned.
+
 ```
-python .\octopose.py -e staging --wait --force
+python .\octopose.py -e staging --wait --force --verbose
 ```
 
 

--- a/generate_manifest.py
+++ b/generate_manifest.py
@@ -2,7 +2,7 @@
 
 # MIT License
 #
-# Copyright (c) 2017 Huddle
+# Copyright (c) 2018 Huddle
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/local_deploy.py
+++ b/local_deploy.py
@@ -30,6 +30,7 @@ import sys
 
 class LocalDeploy:
     def __init__(self, verbose):
+        """LocalDeploy deploys Octopus packages (on the current machine) without needing a tentacle service"""
         self.subprocess_runner = subprocess_runner.SubprocessRunner(verbose)
         self.nu = nu.Nu(self.subprocess_runner)
 

--- a/local_deploy.py
+++ b/local_deploy.py
@@ -1,0 +1,69 @@
+# MIT License
+#
+# Copyright (c) 2018 Huddle
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import subprocess_runner
+import nu
+import os
+import shutil
+import octo
+import sys
+
+
+class LocalDeploy:
+    def __init__(self, verbose):
+        self.subprocess_runner = subprocess_runner.SubprocessRunner(verbose)
+        self.nu = nu.Nu(self.subprocess_runner)
+
+    def invoke_deploy(self, step_path):
+        """invoke_deploy start a deploy for a given powershell script (*Deploy.ps1)"""
+        if os.path.exists(step_path):
+            print("- {0}".format(step_path))
+            if sys.maxsize > 2**32:
+                args = "powershell.exe {0}".format(step_path)
+            else:
+                args = "c:\\windows\\sysnative\\cmd.exe /c powershell.exe {0}".format(step_path)
+            self.subprocess_runner.run(args, "Running of {0} failed".format(step_path))
+
+    def deploy(self, data):
+        """deploy_local will use the manifest to deploy all packages to the local machine"""
+        staging = os.path.normpath(data['StagingLocation'])
+        if os.path.exists(staging):
+            shutil.rmtree(staging)
+        os.makedirs(staging, mode=0o777)
+
+        for key, value in data['Projects'].items():
+            project_name = key
+            print(project_name)
+            proj_id = octo.get_project_id(project_name)
+            if 'Version' not in value:
+                latest_release = octo.get_latest_release(proj_id)
+                version = latest_release['Version']
+            else:
+                version = value['Version']
+
+            for package in value['Packages']:
+                print("- NuGet - {0}".format(package))
+                self.nu.get_deployable(package, version, staging)
+
+                self.invoke_deploy("{0}\{1}.{2}\PreDeploy.ps1".format(staging, package, version))
+                self.invoke_deploy("{0}\{1}.{2}\Deploy.ps1".format(staging, package, version))
+                self.invoke_deploy("{0}\{1}.{2}\PostDeploy.ps1".format(staging, package, version))

--- a/nu.py
+++ b/nu.py
@@ -27,6 +27,7 @@ import config
 
 class Nu:
     def __init__(self, subprocess_runner):
+        """Nu interacts with nuget.exe by running commands in a subprocess"""
         self.subprocess_runner = subprocess_runner
 
     def get_deployable(self, name, version, staging_location):

--- a/nu.py
+++ b/nu.py
@@ -22,17 +22,13 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import os
-import subprocess
-
 import config
+import util
 
 
-def get_deployable(name, version, staging_location):
+def get_deployable(name, version, staging_location, verbose):
     """ Get deployables from pacakage sources for local deployment. """
     for source in config.PACKAGE_SOURCES:
-        FNULL = open(os.devnull, 'w')    #use this if you want to suppress output to stdout from the subprocess
-        args = "third_party\\NuGet.exe install {0} -Source {1} -OutputDirectory {2}".format(name, source, staging_location)
-        if version is not None:
-            args = args + " -Version {0}".format(version)
-        subprocess.call(args, stdout=FNULL, stderr=FNULL, shell=False)
+        args = "third_party\\NuGet.exe install {0} -Source {1} -OutputDirectory {2}".format(name, source,
+                                                                                            staging_location)
+        util.run_subprocess(args, "Getting of {0} at version {1} failed".format(name, version), verbose)

--- a/nu.py
+++ b/nu.py
@@ -2,7 +2,7 @@
 
 # MIT License
 #
-# Copyright (c) 2017 Huddle
+# Copyright (c) 2018 Huddle
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,12 +23,15 @@
 # SOFTWARE.
 
 import config
-import util
 
 
-def get_deployable(name, version, staging_location, verbose):
-    """ Get deployables from pacakage sources for local deployment. """
-    for source in config.PACKAGE_SOURCES:
-        args = "third_party\\NuGet.exe install {0} -Source {1} -OutputDirectory {2}".format(name, source,
-                                                                                            staging_location)
-        util.run_subprocess(args, "Getting of {0} at version {1} failed".format(name, version), verbose)
+class Nu:
+    def __init__(self, subprocess_runner):
+        self.subprocess_runner = subprocess_runner
+
+    def get_deployable(self, name, version, staging_location):
+        """ Get deployables from pacakage sources for local deployment. """
+        for source in config.PACKAGE_SOURCES:
+            args = "third_party\\NuGet.exe install {0} -Source {1} -OutputDirectory {2}".format(name, source,
+                                                                                                staging_location)
+            self.subprocess_runner.run(args, "Getting of {0} at version {1} failed".format(name, version))

--- a/octo.py
+++ b/octo.py
@@ -2,7 +2,7 @@
 
 # MIT License
 #
-# Copyright (c) 2017 Huddle
+# Copyright (c) 2018 Huddle
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/octopose.py
+++ b/octopose.py
@@ -25,7 +25,7 @@
 import json
 import remote_deploy
 import argparse
-import local_deploy
+from local_deploy import LocalDeploy
 import sys
 import octo
 
@@ -65,4 +65,4 @@ if __name__ == "__main__":
     if environment != "local":
         remote_deploy.deploy_to_environment(env_id, wait, force, manifest)
     else:
-        local_deploy.LocalDeploy(verbose).deploy(manifest)
+        LocalDeploy(verbose).deploy(manifest)

--- a/octopose.py
+++ b/octopose.py
@@ -2,7 +2,7 @@
 
 # MIT License
 #
-# Copyright (c) 2017 Huddle
+# Copyright (c) 2018 Huddle
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,120 +23,11 @@
 # SOFTWARE.
 
 import json
-import time
+import remote_deploy
 import argparse
-import shutil
-import os
+import local_deploy
 import sys
 import octo
-import nu
-import util
-
-
-def invoke_deploy(step_path, verbose):
-    """invoke_deploy start a deploy for a given powershell script (*Deploy.ps1)"""
-    if os.path.exists(step_path):
-        print("- {0}".format(step_path))
-        if sys.maxsize > 2**32:
-            args = "powershell.exe {0}".format(step_path)
-        else:
-            args = "c:\\windows\\sysnative\\cmd.exe /c powershell.exe {0}".format(step_path)
-        util.run_subprocess(args, "Running of {0} failed".format(step_path), verbose)
-
-
-def deploy_to_environment(env_id, wait, force, data):
-    """deploy_to_environment will use the manifest to do a remote deploy into another environment"""
-    deployments = {}
-    for key, value in data['Projects'].items():
-        if value is None:
-            continue
-
-        project_name = key
-        proj_id = octo.get_project_id(project_name)
-
-        if 'Version' not in value:
-            latest_release = octo.get_latest_release(proj_id)
-            version = latest_release['Version']
-        else:
-            version = value['Version']
-
-        if version is None:
-            continue
-
-        to_deploy = octo.get_deploy_for_version(proj_id, version)
-        current_deploy = octo.get_deploy_for_env(proj_id, env_id)
-        if version == current_deploy['Version']:
-            last_deploy = octo.get_last_deploy_for_env(proj_id, env_id)
-            last_fail = octo.get_last_failed_deploy_for_env(proj_id, env_id)
-            if (last_fail is not None) and (last_deploy['TaskId'] == last_fail['TaskId']):
-                print("Failed Last Deploy - will try again")
-            elif force:
-                print("Forcing Deploy")
-            else:
-                deployments[project_name] = {'Link': None,
-                                             'Status': 'Already Deployed',
-                                             'Version': version}
-                continue
-
-        if to_deploy:
-            print("{0} - Deploying {1}".format(project_name, version))
-            for package in to_deploy['SelectedPackages']:
-                print("  - {0}".format(package['StepName']))
-            deploy = octo.deploy_release(to_deploy['Id'], env_id)
-            deployments[project_name] = {'Link': deploy['Links']['Task'],
-                                         'Status': 'Queued',
-                                         'Version': version}
-
-    if wait:
-        pending = len(deployments)
-        while pending > 0:
-            for key, value in deployments.items():
-                task_link = value['Link']
-                if task_link is None:
-                    continue
-                task = octo.get_task(task_link)
-                if task['State'] == 'Failed':
-                    deployments[key]['Link'] = None
-                    deployments[key]['Status'] = 'Failed'
-                else:
-                    deployments[key]['Status'] = task['State']
-
-            pending = 0
-            for key, value in deployments.items():
-                status = value['Status']
-                if (status == 'Queued') or (status == 'Executing'):
-                    pending = pending + 1
-                time.sleep(10)
-
-    for key, value in deployments.items():
-        print("{0} - {1} - {2}".format(value['Status'], key,
-                                       value['Version']))
-
-
-def deploy_local(data, verbose):
-    """deploy_local will use the manifest to deploy all packages to the local machine"""
-    staging = os.path.normpath(data['StagingLocation'])
-    if os.path.exists(staging):
-        shutil.rmtree(staging)
-    os.makedirs(staging, mode=0o777)
-
-    for key, value in data['Projects'].items():
-        project_name = key
-        print(project_name)
-        proj_id = octo.get_project_id(project_name)
-        if 'Version' not in value:
-            latest_release = octo.get_latest_release(proj_id)
-            version = latest_release['Version']
-        else:
-            version = value['Version']
-
-        for package in value['Packages']:
-            print("- NuGet - {0}".format(package))
-            nu.get_deployable(package, version, staging, verbose)
-    
-            invoke_deploy("{0}\{1}.{2}\PreDeploy.ps1".format(staging, package, version), verbose)
-            invoke_deploy("{0}\{1}.{2}\Deploy.ps1".format(staging, package, version), verbose)
-            invoke_deploy("{0}\{1}.{2}\PostDeploy.ps1".format(staging, package, version), verbose)
 
 
 if __name__ == "__main__":
@@ -170,7 +61,8 @@ if __name__ == "__main__":
         manifest_string = infile_contents
 
     manifest = json.loads(manifest_string)
+
     if environment != "local":
-        deploy_to_environment(env_id, wait, force, manifest)
+        remote_deploy.deploy_to_environment(env_id, wait, force, manifest)
     else:
-        deploy_local(manifest, verbose)
+        local_deploy.LocalDeploy(verbose).deploy(manifest)

--- a/remote_deploy.py
+++ b/remote_deploy.py
@@ -1,0 +1,94 @@
+# MIT License
+#
+# Copyright (c) 2018 Huddle
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+import octo
+import time
+
+
+def deploy_to_environment(env_id, wait, force, data):
+    """deploy_to_environment will use the manifest to do a remote deploy into another environment"""
+    deployments = {}
+    for key, value in data['Projects'].items():
+        if value is None:
+            continue
+
+        project_name = key
+        proj_id = octo.get_project_id(project_name)
+
+        if 'Version' not in value:
+            latest_release = octo.get_latest_release(proj_id)
+            version = latest_release['Version']
+        else:
+            version = value['Version']
+
+        if version is None:
+            continue
+
+        to_deploy = octo.get_deploy_for_version(proj_id, version)
+        current_deploy = octo.get_deploy_for_env(proj_id, env_id)
+        if version == current_deploy['Version']:
+            last_deploy = octo.get_last_deploy_for_env(proj_id, env_id)
+            last_fail = octo.get_last_failed_deploy_for_env(proj_id, env_id)
+            if (last_fail is not None) and (last_deploy['TaskId'] == last_fail['TaskId']):
+                print("Failed Last Deploy - will try again")
+            elif force:
+                print("Forcing Deploy")
+            else:
+                deployments[project_name] = {'Link': None,
+                                             'Status': 'Already Deployed',
+                                             'Version': version}
+                continue
+
+        if to_deploy:
+            print("{0} - Deploying {1}".format(project_name, version))
+            for package in to_deploy['SelectedPackages']:
+                print("  - {0}".format(package['StepName']))
+            deploy = octo.deploy_release(to_deploy['Id'], env_id)
+            deployments[project_name] = {'Link': deploy['Links']['Task'],
+                                         'Status': 'Queued',
+                                         'Version': version}
+
+    if wait:
+        pending = len(deployments)
+        while pending > 0:
+            for key, value in deployments.items():
+                task_link = value['Link']
+                if task_link is None:
+                    continue
+                task = octo.get_task(task_link)
+                if task['State'] == 'Failed':
+                    deployments[key]['Link'] = None
+                    deployments[key]['Status'] = 'Failed'
+                else:
+                    deployments[key]['Status'] = task['State']
+
+            pending = 0
+            for key, value in deployments.items():
+                status = value['Status']
+                if (status == 'Queued') or (status == 'Executing'):
+                    pending = pending + 1
+                time.sleep(10)
+
+    for key, value in deployments.items():
+        print("{0} - {1} - {2}".format(value['Status'], key,
+                                       value['Version']))

--- a/subprocess_runner.py
+++ b/subprocess_runner.py
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2017 Huddle
+# Copyright (c) 2018 Huddle
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -24,13 +24,17 @@ import subprocess
 import sys
 
 
-def run_subprocess(args, error_msg, verbose):
-    completed_process = subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=False)
+class SubprocessRunner:
+    def __init__(self, verbose):
+        self.verbose = verbose
 
-    if completed_process.returncode != 0:
-        print(completed_process.stdout.decode('utf-8'))
-        print(error_msg, file=sys.stderr)
-        exit()
+    def run(self, args, error_msg):
+        completed_process = subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=False)
 
-    if verbose:
-        print(completed_process.stdout.decode('utf-8'))
+        if completed_process.returncode != 0:
+            print(completed_process.stdout.decode('utf-8'))
+            print(error_msg, file=sys.stderr)
+            exit()
+
+        if self.verbose:
+            print(completed_process.stdout.decode('utf-8'))

--- a/subprocess_runner.py
+++ b/subprocess_runner.py
@@ -26,10 +26,13 @@ import sys
 
 class SubprocessRunner:
     def __init__(self, verbose):
+        """Runs subprocesses and manages logging of outputs"""
         self.verbose = verbose
 
-    def run(self, args, error_msg):
-        completed_process = subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=False)
+    def run(self, command, error_msg):
+        """run the specified command in a subprocess and log the stdout of the subprocess (if it errors or verbose is
+        True) and the error_msg (if it errors)"""
+        completed_process = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=False)
 
         if completed_process.returncode != 0:
             print(completed_process.stdout.decode('utf-8'))

--- a/util.py
+++ b/util.py
@@ -1,0 +1,36 @@
+# MIT License
+#
+# Copyright (c) 2017 Huddle
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import subprocess
+import sys
+
+
+def run_subprocess(args, error_msg, verbose):
+    completed_process = subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=False)
+
+    if completed_process.returncode != 0:
+        print(completed_process.stdout.decode('utf-8'))
+        print(error_msg, file=sys.stderr)
+        exit()
+
+    if verbose:
+        print(completed_process.stdout.decode('utf-8'))


### PR DESCRIPTION
By default octopose now only outputs logs for subprocceses when they return a non-zero exit code (to help with debugging). To get all logs you can use the `-v` or `--verbose` flag.

Solves #14 and #13 