### PR TITLE
Generate manifest has incorrect projects

### DIFF
--- a/generate_manifest.py
+++ b/generate_manifest.py
@@ -62,15 +62,19 @@ if __name__ == '__main__':
                 if specific_versions[project] is None:
                     manifest['Projects'][project] = project_detail = None
                     continue
-                deployment = octo.get_deploy_for_version(project_id, specific_versions[project])
+                release = octo.get_release_for_version(project_id, specific_versions[project])
                 project_detail['Version'] = specific_versions[project]
-                project_detail['Packages'] = octo.get_specific_packages(deployment)
+                project_detail['Packages'] = octo.get_specific_packages(release)
             elif env != "local":
-                deployment = octo.get_deploy_for_env(project_id, environments[env])
-                project_detail['Version'] = deployment['Version']
-                project_detail['Packages'] = octo.get_specific_packages(deployment)
+                print(project_id)
+                print(environments[env])
+                release = octo.get_release_for_env(project_id, environments[env])
+                project_detail['Version'] = release['Version']
+                packages = octo.get_specific_packages(release, environments[env])
+                project_detail['Packages'] = packages
             else:
                 project_detail['Packages'] = octo.get_latest_packages(project_id)
+
             manifest['Projects'][project] = project_detail
 
     print(json.dumps(manifest, indent=1))

--- a/generate_manifest.py
+++ b/generate_manifest.py
@@ -66,8 +66,6 @@ if __name__ == '__main__':
                 project_detail['Version'] = specific_versions[project]
                 project_detail['Packages'] = octo.get_specific_packages(release)
             elif env != "local":
-                print(project_id)
-                print(environments[env])
                 release = octo.get_release_for_env(project_id, environments[env])
                 project_detail['Version'] = release['Version']
                 packages = octo.get_specific_packages(release, environments[env])

--- a/local_deploy.py
+++ b/local_deploy.py
@@ -38,7 +38,7 @@ class LocalDeploy:
         """invoke_deploy start a deploy for a given powershell script (*Deploy.ps1)"""
         if os.path.exists(step_path):
             print("- {0}".format(step_path))
-            if sys.maxsize > 2**32:
+            if is_64_bit_python_installation():
                 args = "powershell.exe {0}".format(step_path)
             else:
                 args = "c:\\windows\\sysnative\\cmd.exe /c powershell.exe {0}".format(step_path)
@@ -68,3 +68,7 @@ class LocalDeploy:
                 self.invoke_deploy("{0}\{1}.{2}\PreDeploy.ps1".format(staging, package, version))
                 self.invoke_deploy("{0}\{1}.{2}\Deploy.ps1".format(staging, package, version))
                 self.invoke_deploy("{0}\{1}.{2}\PostDeploy.ps1".format(staging, package, version))
+
+
+def is_64_bit_python_installation():
+    return sys.maxsize > 2**32

--- a/octo.py
+++ b/octo.py
@@ -74,7 +74,6 @@ def get_release_for_version(proj_id, version):
 def get_release_for_env(proj_id, env_id):
     """get_deploy_for_env will get information about the last deploy of a project onto an environment"""
     uri = config.OCTOPUS_URI + "/api/deployments?environments={0}&projects={1}".format(env_id, proj_id)
-    print(uri)
     r = requests.get(uri, headers=config.OCTOPUS_HEADERS, verify=False)
     if r.status_code == 200:
         uri = config.OCTOPUS_URI + r.json()['Items'][0]['Links']['Release']

--- a/octo.py
+++ b/octo.py
@@ -63,7 +63,7 @@ def get_project_id(name):
 
 
 def get_release_for_version(proj_id, version):
-    """get_deploy_for_version gets the deploy for a project and version"""
+    """get_release_for_version gets the release for a project and version"""
     uri = config.OCTOPUS_URI + "/api/projects/{0}/releases/{1}".format(proj_id, version)
     r = requests.get(uri, headers=config.OCTOPUS_HEADERS, verify=False)
     if r.status_code == 200:
@@ -72,7 +72,7 @@ def get_release_for_version(proj_id, version):
 
 
 def get_release_for_env(proj_id, env_id):
-    """get_deploy_for_env will get information about the last deploy of a project onto an environment"""
+    """get_release_for_env will get information about the last release of a project onto an environment"""
     uri = config.OCTOPUS_URI + "/api/deployments?environments={0}&projects={1}".format(env_id, proj_id)
     r = requests.get(uri, headers=config.OCTOPUS_HEADERS, verify=False)
     if r.status_code == 200:
@@ -88,7 +88,7 @@ def action_is_a_deployable_and_is_deployed_to_environment(action, environment_id
 
 
 def get_specific_packages(release, environment_id=None):
-    """get_specific_packages given a deployment get all the steps needed for a deploy"""
+    """get_specific_packages given a release get all the steps needed for a deploy"""
     uri = config.OCTOPUS_URI + release['Links']['ProjectDeploymentProcessSnapshot']
     r = requests.get(uri, headers=config.OCTOPUS_HEADERS, verify=False)
     if r.status_code == 200:
@@ -105,7 +105,7 @@ def get_specific_packages(release, environment_id=None):
 
 
 def get_latest_packages(proj_id):
-    """get_latest_packages will find the latest deployment and packages for the project"""
+    """get_latest_packages will find the latest deployment process and packages for the project"""
     uri = config.OCTOPUS_URI + "/api/deploymentprocesses/deploymentprocess-{0}/template".format(proj_id)
     r = requests.get(uri, headers=config.OCTOPUS_HEADERS, verify=False)
     res = []

--- a/remote_deploy.py
+++ b/remote_deploy.py
@@ -28,6 +28,7 @@ import time
 def deploy_to_environment(env_id, wait, force, data):
     """deploy_to_environment will use the manifest to do a remote deploy into another environment"""
     deployments = {}
+    print(data)
     for key, value in data['Projects'].items():
         if value is None:
             continue
@@ -44,8 +45,8 @@ def deploy_to_environment(env_id, wait, force, data):
         if version is None:
             continue
 
-        to_deploy = octo.get_deploy_for_version(proj_id, version)
-        current_deploy = octo.get_deploy_for_env(proj_id, env_id)
+        to_deploy = octo.get_release_for_version(proj_id, version)
+        current_deploy = octo.get_release_for_env(proj_id, env_id)
         if version == current_deploy['Version']:
             last_deploy = octo.get_last_deploy_for_env(proj_id, env_id)
             last_fail = octo.get_last_failed_deploy_for_env(proj_id, env_id)

--- a/remote_deploy.py
+++ b/remote_deploy.py
@@ -28,7 +28,6 @@ import time
 def deploy_to_environment(env_id, wait, force, data):
     """deploy_to_environment will use the manifest to do a remote deploy into another environment"""
     deployments = {}
-    print(data)
     for key, value in data['Projects'].items():
         if value is None:
             continue


### PR DESCRIPTION
A fix for #15 

Previously Octopose would (given a Release - though this was named `deployment`) find the names of the packages in the Release and then compare them to those to the steps names in the associated `ProjectDeploymentProcessSnapshot` to find the `PackageIds`. However, the names aren't consistent when you have nested steps (one takes the parent step name and the other the child names).

Instead, it now takes an `EnvironmentId` and checks the `ProjectDeploymentProcessSnapshot` to see whether it's normally deployed to that Environment (an empty collection means it's deployed to all Environments). If no `EnvironmentId` is specified then all deployables from the Release's `ProjectDeploymentProcessSnapshot` are selected.