### PR TITLE
Don't assume the package version is the same as the as the release ve…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Next Release
+* Allow deploying of packages that have a different version to the release version ([#33](https://github.com/HuddleEng/octopose/issues/330))
 
 # v0.2.2
 * Fix local deploy not downloading correct packages when specifying version ([#30](https://github.com/HuddleEng/octopose/issues/30))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Next Release
-* Allow deploying of packages that have a different version to the release version ([#33](https://github.com/HuddleEng/octopose/issues/330))
+* Allow deploying of packages that have a different version to the release version ([#33](https://github.com/HuddleEng/octopose/issues/33))
 
 # v0.2.2
 * Fix local deploy not downloading correct packages when specifying version ([#30](https://github.com/HuddleEng/octopose/issues/30))

--- a/octopose/generate_manifest.py
+++ b/octopose/generate_manifest.py
@@ -65,11 +65,11 @@ def main():
                     continue
                 release = octo.get_release_for_version(project_id, specific_versions[project])
                 project_detail['Version'] = specific_versions[project]
-                project_detail['Packages'] = octo.get_specific_packages(release)
+                project_detail['Packages'] = octo.get_specific_package_ids(release)
             elif env != "local":
                 release = octo.get_release_for_env(project_id, environments[env])
                 project_detail['Version'] = release['Version']
-                packages = octo.get_specific_packages(release, environments[env])
+                packages = octo.get_specific_package_ids(release, environments[env])
                 project_detail['Packages'] = packages
             else:
                 project_detail['Packages'] = octo.get_latest_packages(project_id)

--- a/octopose/local_deploy.py
+++ b/octopose/local_deploy.py
@@ -55,14 +55,13 @@ class LocalDeploy:
         for key, value in data['Projects'].items():
             project_name = key
             proj_id = octo.get_project_id(project_name)
-
             if 'Version' not in value:
                 latest_release = octo.get_latest_release(proj_id)
                 release_version = latest_release['Version']
             else:
                 release_version = value['Version']
-            print("{0} - {1}".format(project_name, release_version))
 
+            print("{0} - {1}".format(project_name, release_version))
             for package in get_package_versions(proj_id, release_version, value['Packages']):
                 package_name = package['PackageId']
                 version = package['Version']
@@ -76,18 +75,19 @@ class LocalDeploy:
 
 def get_package_versions(proj_id, release_version, package_ids_to_deploy):
     release = octo.get_release_for_version(proj_id, release_version)
-    step_names_and_version = release['SelectedPackages']
+    step_names_and_versions = release['SelectedPackages']
     package_ids_and_step_names = octo.get_specific_packages(release)
 
     packages_to_deploy = []
-    for p in step_names_and_version:
-        step_name = p['StepName']
-        version = p['Version']
+    for step_name_and_version in step_names_and_versions:
+        for package_id_and_step_name in package_ids_and_step_names:
 
-        for pp in package_ids_and_step_names:
-            if step_name == pp['StepName']:
-                if pp['PackageId'] in package_ids_to_deploy:
-                    packages_to_deploy.append({"PackageId": pp['PackageId'], "Version": version})
+            if step_name_and_version['StepName'] == package_id_and_step_name['StepName']:
+
+                if package_id_and_step_name['PackageId'] in package_ids_to_deploy:
+                    packages_to_deploy.append({"PackageId": package_id_and_step_name['PackageId'],
+                                               "Version": step_name_and_version['Version']})
+
                 break
 
     return packages_to_deploy

--- a/octopose/octo.py
+++ b/octopose/octo.py
@@ -89,12 +89,13 @@ def action_is_a_deployable_and_is_deployed_to_environment(action, environment_id
 
 
 def get_specific_package_ids(release, environment_id=None):
+    """get_specific_package_ids given a release get all the packageIds needed for a deploy"""
     packages = get_specific_packages(release, environment_id)
     return [p["PackageId"] for p in packages]
 
 
 def get_specific_packages(release, environment_id=None):
-    """get_specific_packages given a release get all the steps needed for a deploy"""
+    """get_specific_packages given a release get all the steps and packageIds needed for a deploy"""
     uri = config.OCTOPUS_URI + release['Links']['ProjectDeploymentProcessSnapshot']
     r = requests.get(uri, headers=config.OCTOPUS_HEADERS, verify=False)
     if r.status_code == 200:

--- a/octopose/octo.py
+++ b/octopose/octo.py
@@ -88,6 +88,11 @@ def action_is_a_deployable_and_is_deployed_to_environment(action, environment_id
         (environment_id is None or len(action['Environments']) == 0 or environment_id in action['Environments'])
 
 
+def get_specific_package_ids(release, environment_id=None):
+    packages = get_specific_packages(release, environment_id)
+    return [p["PackageId"] for p in packages]
+
+
 def get_specific_packages(release, environment_id=None):
     """get_specific_packages given a release get all the steps needed for a deploy"""
     uri = config.OCTOPUS_URI + release['Links']['ProjectDeploymentProcessSnapshot']
@@ -99,8 +104,9 @@ def get_specific_packages(release, environment_id=None):
             for action in step['Actions']:
                 if action_is_a_deployable_and_is_deployed_to_environment(action, environment_id):
                     package_id = action['Properties']['Octopus.Action.Package.PackageId']
-                    if package_id not in packages:
-                        packages.append(package_id)
+                    if package_id not in [p["PackageId"] for p in packages]:
+                        packages.append({"PackageId": package_id,
+                                         "StepName": action['Name']})
 
         return packages
 


### PR DESCRIPTION
…rsion

Fixes #33 

A little bit messy because we have to combine information from three sources: the list of packageIds from the manifest file, the step names and versions from the Release and the packageIds and step names from the DeploymentSnapshot associated with the Release. The  `get_package_versions` is what has this logic - not the most efficient, but these lists are going to be pretty small.

Have also improved the `print` output so that it's more explicit about what Release version and Package versions are actually being deployed.