### PR TITLE
Do not fail multiple project deploys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Next Release
 * Allow deploying of packages that have a different version to the release version ([#33](https://github.com/HuddleEng/octopose/issues/33))
 * Improve logging when can't find *.ps1 file ([#32](https://github.com/HuddleEng/octopose/issues/32))
+* Only fail deploy for given project (and not all projects), if a package deploy step fails ([#34](https://github.com/HuddleEng/octopose/34))
 
 # v0.2.2
 * Fix local deploy not downloading correct packages when specifying version ([#30](https://github.com/HuddleEng/octopose/issues/30))

--- a/octopose/local_deploy.py
+++ b/octopose/local_deploy.py
@@ -77,6 +77,8 @@ class LocalDeploy:
                         break
 
                 if not successful_deployment:
+                    print("WARNING: Deploy of {0} has failed. Skipping any remaining packages in the project."
+                          .format(project_name))
                     break
 
             deployment_results.append((project_name, release_version, successful_deployment))
@@ -109,6 +111,7 @@ def is_64_bit_python_installation():
 
 
 def print_deployment_results(deployment_results):
+    print("")
     print("-- Deployment Results --")
     for result in deployment_results:
         if result[2]:

--- a/octopose/subprocess_runner.py
+++ b/octopose/subprocess_runner.py
@@ -35,11 +35,12 @@ class SubprocessRunner:
         completed_process = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=False)
 
         if completed_process.returncode != 0:
-            print(completed_process.stdout.decode('utf-8'))
+            error_logs = completed_process.stdout.decode('utf-8')
+            print(error_logs)
             print(error_msg, file=sys.stderr)
-            return False
+            return False, "{0} \r\n {1}".format(error_msg, error_logs)
 
         if self.verbose:
             print(completed_process.stdout.decode('utf-8'))
 
-        return True
+        return True, None

--- a/octopose/subprocess_runner.py
+++ b/octopose/subprocess_runner.py
@@ -37,7 +37,9 @@ class SubprocessRunner:
         if completed_process.returncode != 0:
             print(completed_process.stdout.decode('utf-8'))
             print(error_msg, file=sys.stderr)
-            exit(1)
+            return False
 
         if self.verbose:
             print(completed_process.stdout.decode('utf-8'))
+
+        return True


### PR DESCRIPTION
Fixes #34 

So instead of executing `exit(1)` in `subprocess_runner.py`, it now returns a boolean indicating if the step succeeded. A failure stops the deployment of the current project and moves onto the next one. It then prints a lovely summary, e.g.

![image](https://user-images.githubusercontent.com/9038126/41780318-4c64bddc-762c-11e8-877f-b8cfdfb394cf.png)
